### PR TITLE
Fixed CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,6 @@ jobs:
       id: test
       run: |
         cd /home/colcon_ws/
-        colcon test
+        . /opt/ros/foxy/setup.sh
+        colcon test --event-handlers console_direct+
+        colcon test-result


### PR DESCRIPTION
`colcon test` doesn't return an error code if there are test failures. For that we need to run `colcon test-result` after running `colcon test`

Signed-off-by: ahcorde <ahcorde@gmail.com>