### PR TITLE
Fix frame tree model

### DIFF
--- a/ign_rviz_plugins/include/ignition/rviz/plugins/TFDisplay.hpp
+++ b/ign_rviz_plugins/include/ignition/rviz/plugins/TFDisplay.hpp
@@ -63,6 +63,12 @@ class TFDisplay : public MessageDisplay<tf2_msgs::msg::TFMessage>
 {
   Q_OBJECT
 
+  Q_PROPERTY(
+    FrameModel * frameModel
+    READ getFrameModel
+    NOTIFY frameModelChanged
+  )
+
 public:
   /**
    * Constructor for tf visualization plugin
@@ -130,6 +136,21 @@ public:
    */
   Q_INVOKABLE void setFrameVisibility(const QString & _frame, const bool & _visible);
 
+  /**
+   * @brief Get the tree view model
+   * @return Tree view model
+   */
+  Q_INVOKABLE FrameModel * getFrameModel() const
+  {
+    return this->frameModel;
+  }
+
+signals:
+  /**
+   * @brief Notify that tree view has changed
+   */
+  void frameModelChanged();
+
 protected:
   /**
    * @brief Create custom arrow visual for visualizing tf links
@@ -156,7 +177,7 @@ protected:
 
 public:
   // Tree view frame model
-  FrameModel * model;
+  FrameModel * frameModel;
 
 private:
   ignition::rendering::AxisVisualPtr axis;

--- a/ign_rviz_plugins/res/qml/TFDisplay.qml
+++ b/ign_rviz_plugins/res/qml/TFDisplay.qml
@@ -105,7 +105,7 @@ Item {
 
   TreeView {
     id: tree
-    model: FrameModel
+    model: TFDisplay.frameModel
     anchors.left: parent.left
     anchors.right: parent.right
     anchors.bottom: tfDisplay.bottom

--- a/ign_rviz_plugins/src/rviz/plugins/TFDisplay.cpp
+++ b/ign_rviz_plugins/src/rviz/plugins/TFDisplay.cpp
@@ -116,10 +116,8 @@ TFDisplay::TFDisplay()
   this->tfRootVisual = this->scene->CreateVisual();
   this->scene->RootVisual()->AddChild(tfRootVisual);
 
-  this->model = new FrameModel();
-  parentRow = this->model->addParentRow(QString::fromStdString("All Frames"));
-
-  ignition::gui::App()->Engine()->rootContext()->setContextProperty("FrameModel", this->model);
+  this->frameModel = new FrameModel();
+  parentRow = this->frameModel->addParentRow(QString::fromStdString("All Frames"));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -322,8 +320,10 @@ void TFDisplay::refresh()
     parentRow->removeRows(0, parentRow->rowCount());
 
     for (auto frame : frameInfo) {
-      this->model->addFrame(QString::fromStdString(frame.first), parentRow);
+      this->frameModel->addFrame(QString::fromStdString(frame.first), parentRow);
     }
+    // Notify model update
+    frameModelChanged();
   }
 }
 
@@ -399,6 +399,9 @@ void TFDisplay::setFrameVisibility(const QString & _frame, const bool & _visible
 
   // All Frames checkbox checked if all child frames are visible
   parentRow->setData(frameStatus, Qt::CheckStateRole);
+
+  // Notify model update
+  frameModelChanged();
 }
 
 }  // namespace plugins


### PR DESCRIPTION
Signed-off-by: Sarathkrishnan Ramesh <sarathkrishnan99@gmail.com>

TF visulalization plugin had a bug. When multiple TF plugins are loaded, their frame tree model were connected to each other. If one of the checkboxes were clicked the GUI changes were reflected to the other tf plugin as well.